### PR TITLE
Constructor in player sync packet to quitely cancel them from servers

### DIFF
--- a/sledgehammer-bungeecord/src/main/java/com/noahhusby/sledgehammer/addons/terramap/network/packets/mapsync/P2CPlayerSyncPacket.java
+++ b/sledgehammer-bungeecord/src/main/java/com/noahhusby/sledgehammer/addons/terramap/network/packets/mapsync/P2CPlayerSyncPacket.java
@@ -28,6 +28,10 @@ public class P2CPlayerSyncPacket implements IForgePacket {
 	public P2CPlayerSyncPacket(SledgehammerPlayer[] players) {
 		this.players = players;
 	}
+	
+	public P2CPlayerSyncPacket() {
+		this.players = new SledgehammerPlayer[0];
+	}
 
 	@Override
 	public void encode(ByteBuf buf) {


### PR DESCRIPTION
Silence errors when receiving player sync packets from servers or clients. That shouldn't happen in normal conditions, but it appears it often does for some reasons.